### PR TITLE
Configure Formspree IDs via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ This project is a React web application consisting of multiple components that t
 
 3. Configure the necessary environment variables.
 
+   Create a `.env` file (or update your deployment environment) with the following values so the Formspree integration can connect to your account:
+
+   ```bash
+   REACT_APP_FORMSPREE_PROJECT_ID=<your_formspree_project_id>
+   REACT_APP_FORMSPREE_FORM_URL=https://formspree.io/f/<your_form_id>
+   ```
+
+   Replace the placeholders with the IDs provided by Formspree for your project and the form that should receive submissions.
+
 ## Usage
 
 4. Run the application:

--- a/src/App.js
+++ b/src/App.js
@@ -17,10 +17,17 @@ import 'react-chatbot-kit/build/main.css';
 
 function App(){
   const { i18n } = useTranslation();
+  const formspreeProjectId = process.env.REACT_APP_FORMSPREE_PROJECT_ID;
 
   useEffect(() => {
     document.dir = i18n.dir();
   }, [i18n, i18n.language]);
+
+  useEffect(() => {
+    if (!formspreeProjectId) {
+      console.warn('Formspree project ID is not configured. Forms will not submit correctly.');
+    }
+  }, [formspreeProjectId]);
 
 
   return (
@@ -29,9 +36,9 @@ function App(){
 
       <Header/>
 
-      <FormspreeProvider project="{FORMSPREE_PROJECT_ID}">
+      <FormspreeProvider project={formspreeProjectId}>
         <Signup/>
-      </FormspreeProvider>  
+      </FormspreeProvider>
 
 {/*       <Chatbot 
         config={config} 

--- a/src/Signup.js
+++ b/src/Signup.js
@@ -17,11 +17,12 @@ const [inputs, setInputs] = useState({
   email: '',
   message: ''
 })
+const formspreeFormUrl = process.env.REACT_APP_FORMSPREE_FORM_URL;
 
 const handleServerResponse = (ok, msg) => {
   if (ok) {
     setStatus({
-      submitted: true, 
+      submitted: true,
       submitting: false,
       info: { error: false, msg: msg }
     });
@@ -32,9 +33,11 @@ const handleServerResponse = (ok, msg) => {
       message: ''
     });
   } else {
-    setStatus({
+    setStatus(prevStatus => ({
+      ...prevStatus,
+      submitting: false,
       info: { error: true, msg: msg }
-    });
+    }));
     }
   }
 
@@ -53,9 +56,16 @@ const handleServerResponse = (ok, msg) => {
   const handleOnSubmit = e => {
     e.preventDefault()
     setStatus(prevStatus => ({ ...prevStatus, submitting: true }))
+
+    if (!formspreeFormUrl) {
+      console.warn('Formspree form URL is not configured.');
+      handleServerResponse(false, 'Form submission is currently unavailable.');
+      return;
+    }
+
     axios({
       method: 'POST',
-      url: 'https://formspree.io/p/1935891009925807142/f/signup-app',
+      url: formspreeFormUrl,
       data: inputs
     })
     .then(response => {


### PR DESCRIPTION
## Summary
- load the Formspree provider project id from the `REACT_APP_FORMSPREE_PROJECT_ID` environment variable
- submit signup requests to the configured `REACT_APP_FORMSPREE_FORM_URL` and fail gracefully if it is missing
- document the required Formspree environment variables for local and deployed environments

## Testing
- npm test -- --watchAll=false *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f6c173481883329d2d10940edad7e9