### PR TITLE
Use configurable Formspree form id

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This project is a React web application consisting of multiple components that t
 
    ```bash
    REACT_APP_FORMSPREE_PROJECT_ID=<your_formspree_project_id>
+   REACT_APP_FORMSPREE_FORM_ID=<your_live_form_id>
+   # Optional: override the default derived URL if needed
    REACT_APP_FORMSPREE_FORM_URL=https://formspree.io/f/<your_form_id>
    ```
 

--- a/src/Signup.js
+++ b/src/Signup.js
@@ -17,7 +17,10 @@ const [inputs, setInputs] = useState({
   email: '',
   message: ''
 })
-const formspreeFormUrl = process.env.REACT_APP_FORMSPREE_FORM_URL;
+const formspreeFormId = process.env.REACT_APP_FORMSPREE_FORM_ID;
+const formspreeFormUrl = formspreeFormId
+  ? `https://formspree.io/f/${formspreeFormId}`
+  : process.env.REACT_APP_FORMSPREE_FORM_URL;
 
 const handleServerResponse = (ok, msg) => {
   if (ok) {


### PR DESCRIPTION
## Summary
- derive the Formspree submission endpoint from a configurable form ID so production deployments can target the live form
- document the new REACT_APP_FORMSPREE_FORM_ID setting and optional URL override in the setup instructions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6c5a787bc8332b48768728cd26d96