### PR TITLE
Add template for Formspree environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Formspree configuration for local development or deployment environments
+# Rename this file to .env and fill in the values below before running the app
+# or configure the same keys in your hosting provider's environment settings.
+
+# Required: Formspree project identifier
+REACT_APP_FORMSPREE_PROJECT_ID=your_formspree_project_id
+
+# Required: Live form identifier that receives submissions
+REACT_APP_FORMSPREE_FORM_ID=your_formspree_form_id
+
+# Optional: Override the derived submit URL if your setup requires a custom endpoint
+REACT_APP_FORMSPREE_FORM_URL=https://formspree.io/f/your_form_id

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project is a React web application consisting of multiple components that t
 
 3. Configure the necessary environment variables.
 
-   Create a `.env` file (or update your deployment environment) with the following values so the Formspree integration can connect to your account:
+   Duplicate the provided `.env.example` file to `.env` for local development **or** add the same keys to the secret configuration panel offered by your hosting provider. These values allow the Formspree integration to connect to your account during both local builds and production deployments:
 
    ```bash
    REACT_APP_FORMSPREE_PROJECT_ID=<your_formspree_project_id>


### PR DESCRIPTION
## Summary
- add an `.env.example` template that documents the required Formspree secrets
- clarify the README installation step to reference the example file and hosting provider configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6c7402ffc8332a6725bd7598c5571